### PR TITLE
Added support for multiple entity managers

### DIFF
--- a/src/DoctrineQueueProvider.php
+++ b/src/DoctrineQueueProvider.php
@@ -47,7 +47,7 @@ class DoctrineQueueProvider extends ServiceProvider
 
         $this->app->singleton('safeQueue.worker', function ($app) {
             return new Worker($app['queue'], $app['events'],
-                $app['em'], $app['Illuminate\Contracts\Debug\ExceptionHandler']);
+                $app['Doctrine\Common\Persistence\ManagerRegistry'], $app['Illuminate\Contracts\Debug\ExceptionHandler']);
         });
     }
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -3,6 +3,7 @@
 
 namespace MaxBrokman\SafeQueue;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -16,27 +17,27 @@ use Throwable;
 /*final*/ class Worker extends IlluminateWorker
 {
     /**
-     * @var EntityManager
+     * @var ManagerRegistry
      */
-    private $entityManager;
+    protected $managerRegistry;
 
     /**
      * Worker constructor.
      *
      * @param QueueManager     $manager
      * @param Dispatcher       $events
-     * @param EntityManager    $entityManager
+     * @param ManagerRegistry    $managerRegistry
      * @param ExceptionHandler $exceptions
      */
     public function __construct(
         QueueManager $manager,
         Dispatcher $events,
-        EntityManager $entityManager,
+        ManagerRegistry $managerRegistry,
         ExceptionHandler $exceptions
     ) {
         parent::__construct($manager, $events, $exceptions);
 
-        $this->entityManager = $entityManager;
+        $this->managerRegistry = $managerRegistry;
     }
 
     /**
@@ -74,11 +75,11 @@ use Throwable;
      */
     private function assertEntityManagerOpen()
     {
-        if ($this->entityManager->isOpen()) {
-            return;
+        foreach ($this->managerRegistry->getManagers() as $entityManager) {
+            if (!$entityManager->isOpen()) {
+                throw new EntityManagerClosedException;
+            }
         }
-
-        throw new EntityManagerClosedException;
     }
 
     /**
@@ -86,7 +87,9 @@ use Throwable;
      */
     private function assertEntityManagerClear()
     {
-        $this->entityManager->clear();
+        foreach ($this->managerRegistry->getManagers() as $entityManager) {
+            $entityManager->clear();
+        }
     }
 
     /**
@@ -96,11 +99,13 @@ use Throwable;
      */
     private function assertGoodDatabaseConnection()
     {
-        $connection = $this->entityManager->getConnection();
+        foreach ($this->managerRegistry->getManagers() as $entityManager) {
+            $connection = $entityManager->getConnection();
 
-        if ($connection->ping() === false) {
-            $connection->close();
-            $connection->connect();
+            if ($connection->ping() === false) {
+                $connection->close();
+                $connection->connect();
+            }
         }
     }
 }


### PR DESCRIPTION
REF: https://github.com/maxbrokman/SafeQueue/pull/20

(Not sure if this should be merged. Seems to check all the EMs, not only the ones used in the worker. Maybe thats ok, maybe not. Not sure yet.)