### PR TITLE
Laravel 10 and `laravel-doctrine/orm:2.0@dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0.2",
-        "illuminate/queue": "^8.0 || ^9.0",
-        "laravel-doctrine/orm": "^1.7"
+        "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
+        "laravel-doctrine/orm": "^1.7 || ^2.0@dev"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",


### PR DESCRIPTION
will want remove `@dev` when we release orm 2.0 fully