### PR TITLE
PCT-11261 | Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0.2",
-        "illuminate/queue": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/queue": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "laravel-doctrine/orm": "^1.7 || ^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
Widens illuminate/queue constraint to include ^11.0 for the L10 → L13 upgrade project. Worker may need updates once on L11 runtime; this PR only opens the version matrix.